### PR TITLE
adding transient keywords on the runnerThread in Unit file

### DIFF
--- a/DCS-game/src/distributed/systems/das/units/Player.java
+++ b/DCS-game/src/distributed/systems/das/units/Player.java
@@ -46,6 +46,12 @@ public class Player extends Unit implements Runnable, Serializable {
 
 		if (!spawn(x, y))
 			return; // We could not spawn on the battlefield
+        /**
+         * update the local position
+         * @author Ma
+         */
+        this.x = x;
+        this.y = y;
 
 		/* Create a new player thread */
 		//new Thread(this).start();

--- a/DCS-game/src/distributed/systems/das/units/Unit.java
+++ b/DCS-game/src/distributed/systems/das/units/Unit.java
@@ -349,6 +349,13 @@ public abstract class Unit implements Serializable, IMessageReceivedHandler {
 				return;
 		}
 
+        /**
+         * update the location
+         * @author MA
+         */
+        this.x = x;
+        this.y = y;
+
 		// Remove the result from the messageList
 		messageList.put(id, null);
 	}


### PR DESCRIPTION
it seems thread in Unit class can not be Serialized. I add the transient keyword.
I am not sure if there is another way to do this (without changing the code under core/ )
It can run now. 
##### Some problems remain:
- move unit still work strange, there are bugs when unit change the location 
- I think  BattleField calling unit.setPosition(x, y); is wrong 
